### PR TITLE
Function Import-oVirtCertificate updated

### DIFF
--- a/PoSh-oVirt.psd1
+++ b/PoSh-oVirt.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PoSh-oVirt.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.5.5.153006'
+ModuleVersion = '4.5.5.153007'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PoSh-oVirt.psm1
+++ b/PoSh-oVirt.psm1
@@ -1000,7 +1000,7 @@ Function Import-oVirtCertificate{
 					$oVirt_SelfSigned_CRT = Invoke-RestMethod -Uri $CertURL -EV WebError
 				}Catch{
 					IF($WebError){
-						$FormattedWebError = (Format-WebError -WebError $WebError -Body $Null -Uri $CertURL); Write-Error $FormattedWebError; $FormattedWebError; Break
+						$FormattedWebError = (Format-WebError -WebError $WebError -Body $Null -Uri $CertURL); $oVirt_SelfSigned_CRT = $Null; Write-Error $FormattedWebError; $FormattedWebError;
 					}Else{Write-Warning "FAILED to Retrieve oVirt Self-Signed Cert from [$($CertURL)]"}
 				}
 			}


### PR DESCRIPTION
Function Import-oVirtCertificate


# Description

Updated line 1003
Fixes # (issue)
removed "BREAK" to prevent exiting script it OLVM host not Online
Was passing up through the PSCallStack and ending scripts
Replaced with action to Null a variable

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
In the lab and production